### PR TITLE
Kossi contrib

### DIFF
--- a/packages/slate-plugins/src/handlers/autoformat/withAutoformat.ts
+++ b/packages/slate-plugins/src/handlers/autoformat/withAutoformat.ts
@@ -12,6 +12,17 @@ import { WithAutoformatOptions } from './types';
  * Enables support for autoformatting actions.
  * Once a markup rule is validated, it does not check the following rules.
  */
+
+ 
+const isMarkupInTextFromBlockStart = (markups: string[], text: string) => {
+  for (const markup of markups) {
+    if (text.includes(markup)) {
+      return true
+    }
+  }
+  return false
+}
+
 export const withAutoformat = ({ rules }: WithAutoformatOptions) => <
   T extends Editor
 >(
@@ -45,7 +56,7 @@ export const withAutoformat = ({ rules }: WithAutoformatOptions) => <
 
       const valid = () => insertTrigger && insertText(text);
 
-      if (markups.includes(textFromBlockStart)) {
+      if (isMarkupInTextFromBlockStart(markups, textFromBlockStart)) {
         // Start of the block
         autoformatBlock(editor, type, rangeFromBlockStart, {
           preFormat,
@@ -81,3 +92,4 @@ export const withAutoformat = ({ rules }: WithAutoformatOptions) => <
 
   return editor;
 };
+

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -7,7 +7,7 @@ import {
   toggleList,
   unwrapList,
 } from '@udecode/slate-plugins';
-import { Editor } from 'slate';
+import { Editor, Transforms } from 'slate';
 import { options } from './initialValues';
 
 const preFormat = (editor: Editor) => unwrapList(editor, options);
@@ -67,6 +67,12 @@ export const autoformatRules: AutoformatRule[] = [
     type: options.blockquote.type,
     markup: ['>'],
     preFormat,
+    format: (editor) => {
+      Transforms.wrapNodes(editor, {
+        type: options.blockquote.type,
+        children: [{text: ''}]
+      })
+    }
   },
   {
     type: MARK_BOLD,


### PR DESCRIPTION
## Issue
Fix the issue link to inserting list in blockquote


## What I did
* Enhanced autoformatplugin to handle markups included in text
* Updated the default autoformatRules for blockquote to wrap its content (list for instance). You can exit a blockquote with Ctrl+enter



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->